### PR TITLE
TMS-2128 support for TCP tunnels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: go
-go: 
-  - 1.4
-  - tip
+
+sudo: false
+
+go:
+  - 1.4.3
+  - 1.5.3
+
 script:
-  - go build -v
-  - go test -v -race
+  - export GOMAXPROCS=$(nproc)
+  - go build ./...
+  - go test -race ./...

--- a/client.go
+++ b/client.go
@@ -65,6 +65,12 @@ type ClientConfig struct {
 	// tunnelserver's public exposed Port.
 	LocalAddr string
 
+	// FetchLocalAddr is used for looking up TCP address of the server,
+	// which an incoming connection should be proxied to.
+	//
+	// If nil, "127.0.0.1:port" will be used instead.
+	FetchLocalAddr func(port int) (string, error)
+
 	// Debug enables debug mode, enable only if you want to debug the server.
 	Debug bool
 
@@ -331,17 +337,60 @@ func (c *Client) listenControl(ct *control) error {
 
 		switch msg.Action {
 		case requestClientSession:
-			c.log.Debug("Received request to open a session to server")
-			go func() {
-				if err := c.proxy(msg.LocalPort); err != nil {
-					c.log.Error("Proxy err between remote and local: '%s'", err)
-				}
-			}()
+			switch msg.Protocol {
+			case tcpTransport:
+				c.log.Debug("Received request to open a TCP session to server")
+
+				go func() {
+					if err := c.proxyTCP(msg.LocalPort); err != nil {
+						c.log.Error("proxying between remote and local failed: %s", err)
+					}
+				}()
+
+			case httpTransport:
+				c.log.Debug("Received request to open a HTTP session to server")
+
+				go func() {
+					if err := c.proxyHTTP(msg.LocalPort); err != nil {
+						c.log.Error("Proxy err between remote and local: '%s'", err)
+					}
+				}()
+			}
 		}
 	}
 }
 
-func (c *Client) proxy(port int) error {
+func (c *Client) proxyTCP(port int) error {
+	c.log.Debug("Opening a new stream from server session")
+
+	remote, err := c.session.Open()
+	if err != nil {
+		return err
+	}
+	defer remote.Close()
+
+	localAddr := fmt.Sprintf("127.0.0.1:%d", port)
+	if c.config.FetchLocalAddr != nil {
+		localAddr, err = c.config.FetchLocalAddr(port)
+		if err != nil {
+			return fmt.Errorf("failed to fetch LocalAddr for port %d: %s", port, err)
+		}
+	}
+
+	c.log.Debug("Dialing local server: %s", localAddr)
+
+	local, err := net.DialTimeout("tcp", localAddr, defaultTimeout)
+	if err != nil {
+		c.log.Error("dialing local server %s failed: %s", localAddr, err)
+		return err
+	}
+
+	c.join(local, remote)
+
+	return nil
+}
+
+func (c *Client) proxyHTTP(port int) error {
 	c.log.Debug("Opening a new stream from server session")
 	remote, err := c.session.Open()
 	if err != nil {
@@ -352,16 +401,15 @@ func (c *Client) proxy(port int) error {
 	if port == 0 {
 		port = 80
 	}
-
 	localAddr := "127.0.0.1:" + strconv.Itoa(port)
 	if c.config.LocalAddr != "" {
 		localAddr = c.config.LocalAddr
 	}
 
-	c.log.Debug("Dialing local server %s", localAddr)
-	local, err := net.Dial("tcp", localAddr)
+	c.log.Debug("Dialing local server: %s", localAddr)
+	local, err := net.DialTimeout("tcp", localAddr, defaultTimeout)
 	if err != nil {
-		c.log.Debug("Dialing local server(%s) failed: %s", localAddr, err)
+		c.log.Error("dialing local server %s failed: %s", localAddr, err)
 
 		// send a response instead of canceling it on the server side. at least
 		// the public connection will know what's happening or not
@@ -384,21 +432,21 @@ func (c *Client) proxy(port int) error {
 		return nil
 	}
 
-	c.log.Debug("Starting to proxy between remote and local server")
 	c.reqWg.Add(1)
 	c.join(local, remote)
 	c.reqWg.Done()
 
-	c.log.Debug("Proxing between remote and local server finished")
 	return nil
 }
 
-func (c *Client) join(local, remote io.ReadWriteCloser) {
+func (c *Client) join(local, remote net.Conn) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 
-	transfer := func(side string, dst, src io.ReadWriteCloser) {
-		_, err := io.Copy(dst, src)
+	transfer := func(side string, dst, src net.Conn) {
+		c.log.Debug("proxing %s -> %s", src.RemoteAddr(), dst.RemoteAddr())
+
+		n, err := io.Copy(dst, src)
 		if err != nil {
 			c.log.Debug("copy error: %s\n", err.Error())
 		}
@@ -415,11 +463,11 @@ func (c *Client) join(local, remote io.ReadWriteCloser) {
 		}
 
 		wg.Done()
+		c.log.Debug("done proxing %s -> %s: %d bytes", src.RemoteAddr(), dst.RemoteAddr(), n)
 	}
 
 	go transfer("remote to local", local, remote)
 	go transfer("local to remote", remote, local)
 
 	wg.Wait()
-	return
 }

--- a/client.go
+++ b/client.go
@@ -427,7 +427,7 @@ func (c *Client) proxyHTTP(port int) error {
 		buf := new(bytes.Buffer)
 		resp.Write(buf)
 		if _, err := io.Copy(remote, buf); err != nil {
-			c.log.Debug("copy in-mem response error: %s\n", err.Error())
+			c.log.Debug("copy in-mem response error: %s", err)
 		}
 		return nil
 	}
@@ -448,17 +448,17 @@ func (c *Client) join(local, remote net.Conn) {
 
 		n, err := io.Copy(dst, src)
 		if err != nil {
-			c.log.Debug("copy error: %s\n", err.Error())
+			c.log.Error("%s: copy error: %s", side, err)
 		}
 
 		if err := src.Close(); err != nil {
-			c.log.Debug("%s: close error: %s\n", side, err.Error())
+			c.log.Debug("%s: close error: %s", side, err)
 		}
 
 		// not for yamux streams, but for client to local server connections
 		if d, ok := dst.(*net.TCPConn); ok {
 			if err := d.CloseWrite(); err != nil {
-				c.log.Debug("%s: closeWrite error: %s\n", side, err.Error())
+				c.log.Debug("%s: closeWrite error: %s", side, err)
 			}
 		}
 

--- a/control.go
+++ b/control.go
@@ -7,9 +7,7 @@ import (
 	"sync"
 )
 
-var (
-	errControlClosed = errors.New("control connection is closed")
-)
+var errControlClosed = errors.New("control connection is closed")
 
 type control struct {
 	// enc and dec are responsible for encoding and decoding json values forth

--- a/protocol.go
+++ b/protocol.go
@@ -24,6 +24,7 @@ type transportProtocol int
 
 const (
 	httpTransport transportProtocol = iota + 1
+	tcpTransport
 )
 
 type controlMsg struct {

--- a/virtualaddr.go
+++ b/virtualaddr.go
@@ -1,0 +1,172 @@
+package tunnel
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+
+	"github.com/koding/logging"
+)
+
+type listener struct {
+	net.Listener
+	*vaddrOptions
+
+	done int32
+
+	// ips keeps track of registered clients for ip-based routing;
+	// when last client is deleted from the ip routing map, we stop
+	// listening on connections
+	ips map[string]struct{}
+}
+
+func (vaddr *vaddrStorage) newListener(l net.Listener) *listener {
+	return &listener{
+		Listener:     l,
+		vaddrOptions: vaddr.vaddrOptions,
+		ips:          make(map[string]struct{}),
+	}
+}
+
+func (l *listener) serve() {
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			l.log.Error("failue listening on %q: %s", l.Addr(), err)
+			return
+		}
+
+		if atomic.LoadInt32(&l.done) != 0 {
+			l.log.Debug("stopped serving %q", l.Addr())
+			conn.Close()
+			return
+		}
+
+		l.connCh <- conn
+	}
+}
+
+func (l *listener) localAddr() string {
+	if addr, ok := l.Addr().(*net.TCPAddr); ok {
+		if addr.IP.Equal(net.IPv4zero) {
+			return fmt.Sprintf("127.0.0.1:%d", addr.Port)
+		}
+	}
+	return l.Addr().String()
+}
+
+func (l *listener) stop() {
+	if atomic.CompareAndSwapInt32(&l.done, 0, 1) {
+		// self-pipe to break out of serve loop
+		conn, err := net.DialTimeout("tcp", l.localAddr(), defaultTimeout)
+		if err == nil {
+			conn.Close()
+		}
+	}
+}
+
+type vaddrStorage struct {
+	*vaddrOptions
+
+	listeners map[net.Listener]*listener
+	ports     map[int]string    // port-based routing: maps port number to identifier
+	ips       map[string]string // ip-based routing: maps ip address to identifier
+
+	mu sync.RWMutex
+}
+
+type vaddrOptions struct {
+	connCh chan<- net.Conn
+	log    logging.Logger
+}
+
+func newVirtualAddrs(opts *vaddrOptions) *vaddrStorage {
+	return &vaddrStorage{
+		vaddrOptions: opts,
+		listeners:    make(map[net.Listener]*listener),
+		ports:        make(map[int]string),
+		ips:          make(map[string]string),
+	}
+}
+
+func mustPort(l net.Listener) int {
+	_, port, err := parseHostPort(l.Addr().String())
+	if err != nil {
+		// This can happend when user passed custom type that
+		// implements net.Listener, which returns ill-formed
+		// net.Addr value.
+		panic("ill-formed net.Addr: " + err.Error())
+	}
+
+	return port
+}
+
+func (vaddr *vaddrStorage) Add(l net.Listener, ip net.IP, ident string) {
+	vaddr.mu.Lock()
+	defer vaddr.mu.Unlock()
+
+	lis, ok := vaddr.listeners[l]
+	if !ok {
+		lis = vaddr.newListener(l)
+		vaddr.listeners[l] = lis
+		go lis.serve()
+	}
+
+	if ip != nil {
+		lis.ips[ip.String()] = struct{}{}
+		vaddr.ips[ip.String()] = ident
+	} else {
+		vaddr.ports[mustPort(l)] = ident
+	}
+}
+
+func (vaddr *vaddrStorage) Delete(l net.Listener, ip net.IP) {
+	vaddr.mu.Lock()
+	defer vaddr.mu.Unlock()
+
+	lis, ok := vaddr.listeners[l]
+	if !ok {
+		return
+	}
+
+	var stop bool
+
+	if ip != nil {
+		delete(lis.ips, ip.String())
+		delete(vaddr.ips, ip.String())
+
+		stop = len(lis.ips) == 0
+	} else {
+		delete(vaddr.ports, mustPort(l))
+
+		stop = true
+	}
+
+	// Only stop listening for connections when listener has clients
+	// registered to tunnel the connections to.
+	if stop {
+		lis.stop()
+		delete(vaddr.listeners, l)
+	}
+}
+
+func (vaddr *vaddrStorage) getIdent(conn net.Conn) (string, bool) {
+	vaddr.mu.Lock()
+	defer vaddr.mu.Unlock()
+
+	ip, port, err := parseHostPort(conn.LocalAddr().String())
+	if err != nil {
+		vaddr.log.Debug("failed to get identifier for connection %q: %s", conn.LocalAddr(), err)
+		return "", false
+	}
+
+	// First lookup if there's a ip-based route, then try port-base one.
+
+	if ident, ok := vaddr.ips[ip]; ok {
+		return ident, true
+	}
+
+	ident, ok := vaddr.ports[port]
+	return ident, ok
+}


### PR DESCRIPTION
This CL adds support for TCP tunnels, with support for either port-based or IP-based routing.
