### PR TITLE
client: various race fixes 

### DIFF
--- a/tunnel_test.go
+++ b/tunnel_test.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/koding/tunnel"
 	"github.com/koding/tunnel/tunneltest"
@@ -199,9 +198,6 @@ func TestSingleLatencyRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer tt.Close()
-
-	// wait til the environment is ready, just for test
-	time.Sleep(time.Second * 2)
 
 	msg := "hello"
 	res, err := echoHTTP(tt, msg)

--- a/util.go
+++ b/util.go
@@ -1,5 +1,10 @@
 package tunnel
 
+import (
+	"fmt"
+	"sync"
+)
+
 // async is a helper function to convert a blocking function to a function
 // returning an error. Useful for plugging function closures into select and co
 func async(fn func() error) <-chan error {
@@ -14,4 +19,54 @@ func async(fn func() error) <-chan error {
 	}()
 
 	return errChan
+}
+
+type callbacks struct {
+	mu    sync.Mutex
+	name  string
+	funcs map[string]func() error
+}
+
+func newCallbacks(name string) *callbacks {
+	return &callbacks{
+		name:  name,
+		funcs: make(map[string]func() error),
+	}
+}
+
+func (c *callbacks) add(ident string, fn func() error) {
+	c.mu.Lock()
+	c.funcs[ident] = fn
+	c.mu.Unlock()
+}
+
+func (c *callbacks) pop(ident string) (func() error, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	fn, ok := c.funcs[ident]
+	if !ok {
+		return nil, nil // nop
+	}
+
+	delete(c.funcs, ident)
+
+	if fn == nil {
+		return nil, fmt.Errorf("%s: nil callback set for %q client", ident)
+	}
+
+	return fn, nil
+}
+
+func (c *callbacks) call(ident string) error {
+	fn, err := c.pop(ident)
+	if err != nil {
+		return err
+	}
+
+	if fn == nil {
+		return nil // nop
+	}
+
+	return fn()
 }


### PR DESCRIPTION
Fixes all races, old and new ones. All, since running -race with stress goes ok without failures until all available socket fds get depleted ;)

```
$ go test -race -c .
$ stress ./tunnel.test                                                                                                                                                                                                                            
0 runs so far, 0 failures
8 runs so far, 0 failures
9 runs so far, 0 failures
16 runs so far, 0 failures
17 runs so far, 0 failures
20 runs so far, 0 failures
...
```

/cc @cihangir