### PR TITLE
Close proxy connections when finished with transfer

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -73,7 +73,7 @@ func Join(local, remote net.Conn, log logging.Logger) {
 
 	transfer := func(side string, dst, src net.Conn) {
 		log.Debug("proxing %s -> %s", src.RemoteAddr(), dst.RemoteAddr())
-
+		defer dst.Close()
 		n, err := io.Copy(dst, src)
 		if err != nil {
 			log.Error("%s: copy error: %s", side, err)


### PR DESCRIPTION
This PR closes the proxy connections after a transfer is completed.

This specifically addresses situations where the browser will wait for the connection to close explicitly before fully loading the page (e.g. when Content-Length=-1).

I've left the source connection open since this is used to maintain keep alive connections on the client side from my understanding of the net.http/response `Response` docs.